### PR TITLE
feat: Implement in-game HUD with speed, position, and points display

### DIFF
--- a/frontend/src/components/HUD/PointsDisplay.tsx
+++ b/frontend/src/components/HUD/PointsDisplay.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface PointsDisplayProps {
+  points: number;
+}
+
+const PointsDisplay: React.FC<PointsDisplayProps> = ({ points }) => {
+  return (
+    <div style={{
+      position: 'absolute',
+      top: '10px',
+      left: '10px',
+      padding: '10px',
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      color: 'white',
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '16px',
+      borderRadius: '5px',
+      zIndex: 100, // Ensure it's above other elements
+    }}>
+      Points: {points}
+    </div>
+  );
+};
+
+export default PointsDisplay;

--- a/frontend/src/components/HUD/PositionDisplay.tsx
+++ b/frontend/src/components/HUD/PositionDisplay.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface PositionDisplayProps {
+  currentPosition: 1 | 2;
+  totalRacers: number;
+}
+
+const PositionDisplay: React.FC<PositionDisplayProps> = ({ currentPosition, totalRacers }) => {
+  return (
+    <div style={{
+      position: 'absolute',
+      top: '10px',
+      left: '50%',
+      transform: 'translateX(-50%)', // Center align
+      padding: '10px',
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      color: 'white',
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '16px',
+      borderRadius: '5px',
+      zIndex: 100, // Ensure it's above other elements
+    }}>
+      Position: {currentPosition}/{totalRacers}
+    </div>
+  );
+};
+
+export default PositionDisplay;

--- a/frontend/src/components/HUD/SpeedDisplay.tsx
+++ b/frontend/src/components/HUD/SpeedDisplay.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface SpeedDisplayProps {
+  speed: number;
+}
+
+const SpeedDisplay: React.FC<SpeedDisplayProps> = ({ speed }) => {
+  return (
+    <div style={{
+      position: 'absolute',
+      top: '10px',
+      right: '10px',
+      padding: '10px',
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      color: 'white',
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '16px',
+      borderRadius: '5px',
+      zIndex: 100, // Ensure it's above other elements
+    }}>
+      Speed: {speed.toFixed(2)} km/h
+    </div>
+  );
+};
+
+export default SpeedDisplay;


### PR DESCRIPTION
Adds an in-game Heads-Up Display (HUD) to the GameScreen, providing you with real-time information about your performance.

The HUD includes the following elements:
- SpeedDisplay: Shows your current speed, derived from the bicycle's physics state. Speed is calculated from the horizontal velocity of the rear wheel and updated periodically.
- PositionDisplay: Displays your race position (e.g., "1st/2nd") relative to your opponent. Position is determined by comparing the x-coordinates of you and your opponent.
- PointsDisplay: Shows your collected in-game currency/points, using the existing score mechanism in GameScreen.

New React components for each HUD element have been created in `frontend/src/components/HUD/`. These components are styled for readability and positioned at the top-right (Speed), top-center (Position), and top-left (Points) of the game screen. All HUD elements have a `zIndex` of 100 to ensure they are displayed above other game elements. The existing score display in `GameScreen.tsx` has been replaced by the new `PointsDisplay` component.